### PR TITLE
Score modifiers

### DIFF
--- a/fonts_styles_themes/modifier_text_style.tres
+++ b/fonts_styles_themes/modifier_text_style.tres
@@ -1,0 +1,9 @@
+[gd_resource type="LabelSettings" format=3 uid="uid://cnfrremhxjcw1"]
+
+[resource]
+resource_name = "modifier_text_style"
+font_size = 26
+font_color = Color(0.0687983, 0.0687983, 0.0687983, 1)
+outline_size = 1
+shadow_size = 3
+shadow_color = Color(0, 0, 0, 0.301961)

--- a/scenes/packed_scenes/circle.tscn
+++ b/scenes/packed_scenes/circle.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=6 format=3 uid="uid://bxv2hfmql2u5k"]
+[gd_scene load_steps=7 format=3 uid="uid://bxv2hfmql2u5k"]
 
 [ext_resource type="Texture2D" uid="uid://bt8ro8wm61huq" path="res://sprites/circle_temp.png" id="1_8gisg"]
 [ext_resource type="Script" path="res://scripts/circle.gd" id="1_msj54"]
+[ext_resource type="LabelSettings" uid="uid://cnfrremhxjcw1" path="res://fonts_styles_themes/modifier_text_style.tres" id="3_4pgpj"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_f2x8m"]
 friction = 0.17
@@ -35,3 +36,20 @@ debug_color = Color(0.908816, 0.26701, 0.355275, 0.42)
 [node name="Sprite2D" type="Sprite2D" parent="Node2D"]
 scale = Vector2(0.1, 0.1)
 texture = ExtResource("1_8gisg")
+
+[node name="SizeLabel" type="Label" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -20.0
+offset_top = -11.5
+offset_right = 20.0
+offset_bottom = 11.5
+grow_horizontal = 2
+grow_vertical = 2
+text = "-"
+label_settings = ExtResource("3_4pgpj")
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/scenes/packed_scenes/circle_ui.tscn
+++ b/scenes/packed_scenes/circle_ui.tscn
@@ -1,16 +1,40 @@
-[gd_scene load_steps=3 format=3 uid="uid://cv07kcxkrys4i"]
+[gd_scene load_steps=4 format=3 uid="uid://cv07kcxkrys4i"]
 
 [ext_resource type="Texture2D" uid="uid://bt8ro8wm61huq" path="res://sprites/circle_temp.png" id="1_jsrlv"]
 [ext_resource type="Script" path="res://scripts/circle_ui.gd" id="1_qd6e7"]
+[ext_resource type="LabelSettings" uid="uid://cnfrremhxjcw1" path="res://fonts_styles_themes/modifier_text_style.tres" id="3_g32pt"]
 
 [node name="Control" type="Control"]
 custom_minimum_size = Vector2(80, 80)
 layout_mode = 3
 anchors_preset = 0
+offset_left = -40.0
+offset_top = -40.0
+offset_right = 40.0
+offset_bottom = 40.0
 script = ExtResource("1_qd6e7")
 
 [node name="Node2D" type="Node2D" parent="."]
+position = Vector2(40, 40)
 
 [node name="Sprite2D" type="Sprite2D" parent="Node2D"]
 scale = Vector2(0.1, 0.1)
 texture = ExtResource("1_jsrlv")
+
+[node name="SizeLabel" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -0.5
+offset_top = -11.5
+offset_right = 0.5
+offset_bottom = 11.5
+grow_horizontal = 2
+grow_vertical = 2
+text = "-"
+label_settings = ExtResource("3_g32pt")
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/scenes/packed_scenes/modifier_ui.tscn
+++ b/scenes/packed_scenes/modifier_ui.tscn
@@ -1,0 +1,37 @@
+[gd_scene load_steps=2 format=3 uid="uid://bcl4h6p5ngtub"]
+
+[ext_resource type="LabelSettings" uid="uid://cnfrremhxjcw1" path="res://fonts_styles_themes/modifier_text_style.tres" id="1_iwovq"]
+
+[node name="ModifierUI" type="Node2D"]
+
+[node name="Polygon2D" type="Polygon2D" parent="."]
+color = Color(0.720467, 0.720468, 0.720467, 1)
+polygon = PackedVector2Array(-100, 0, -100, 100, 100, 100, 100, 0)
+
+[node name="ModifierName" type="Label" parent="."]
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -52.5
+offset_top = -4.0
+offset_right = 52.5
+offset_bottom = 32.0
+grow_horizontal = 2
+text = "test text"
+label_settings = ExtResource("1_iwovq")
+horizontal_alignment = 1
+
+[node name="ModifierDescription" type="Label" parent="."]
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -90.0
+offset_top = 29.0
+offset_right = 270.0
+offset_bottom = 143.0
+grow_horizontal = 2
+scale = Vector2(0.5, 0.5)
+text = "test text test texttest text test text test text test texttest text test text"
+label_settings = ExtResource("1_iwovq")
+horizontal_alignment = 1
+autowrap_mode = 2

--- a/scenes/packed_scenes/modifier_ui.tscn
+++ b/scenes/packed_scenes/modifier_ui.tscn
@@ -2,13 +2,21 @@
 
 [ext_resource type="LabelSettings" uid="uid://cnfrremhxjcw1" path="res://fonts_styles_themes/modifier_text_style.tres" id="1_iwovq"]
 
-[node name="ModifierUI" type="Node2D"]
+[node name="ModifierUI" type="Control"]
+custom_minimum_size = Vector2(200, 100)
+layout_mode = 3
+anchors_preset = 0
+offset_left = -100.0
+offset_right = 100.0
+offset_bottom = 100.0
 
 [node name="Polygon2D" type="Polygon2D" parent="."]
 color = Color(0.720467, 0.720468, 0.720467, 1)
+offset = Vector2(100, 0)
 polygon = PackedVector2Array(-100, 0, -100, 100, 100, 100, 100, 0)
 
 [node name="ModifierName" type="Label" parent="."]
+layout_mode = 1
 anchors_preset = 5
 anchor_left = 0.5
 anchor_right = 0.5
@@ -22,6 +30,7 @@ label_settings = ExtResource("1_iwovq")
 horizontal_alignment = 1
 
 [node name="ModifierDescription" type="Label" parent="."]
+layout_mode = 1
 anchors_preset = 5
 anchor_left = 0.5
 anchor_right = 0.5

--- a/scenes/packed_scenes/modifiers/test_modifier.tscn
+++ b/scenes/packed_scenes/modifiers/test_modifier.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://c4rj1nhxck7b3"]
+
+[ext_resource type="Script" path="res://scripts/modifiers/test_modifier.gd" id="1_j2mgf"]
+
+[node name="test_modifier" type="Node2D"]
+script = ExtResource("1_j2mgf")

--- a/scenes/packed_scenes/modifiers/test_modifier.tscn
+++ b/scenes/packed_scenes/modifiers/test_modifier.tscn
@@ -2,5 +2,9 @@
 
 [ext_resource type="Script" path="res://scripts/modifiers/test_modifier.gd" id="1_j2mgf"]
 
-[node name="test_modifier" type="Node2D"]
+[node name="test_modifier" type="Control"]
+custom_minimum_size = Vector2(0, 100)
+layout_mode = 3
+anchors_preset = 0
+offset_bottom = 100.0
 script = ExtResource("1_j2mgf")

--- a/scenes/packed_scenes/ship.tscn
+++ b/scenes/packed_scenes/ship.tscn
@@ -79,5 +79,8 @@ grow_horizontal = 0
 [node name="test_modifier" parent="CanvasLayer/UI_Modifiers" instance=ExtResource("7_a7hj1")]
 layout_mode = 2
 
+[node name="test_modifier2" parent="CanvasLayer/UI_Modifiers" instance=ExtResource("7_a7hj1")]
+layout_mode = 2
+
 [connection signal="shot_fired" from="." to="FiringSystem" method="on_shot_fired"]
 [connection signal="body_entered" from="crush_detect" to="." method="_on_body_enter"]

--- a/scenes/packed_scenes/ship.tscn
+++ b/scenes/packed_scenes/ship.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=3 uid="uid://bnlxbdblgsb27"]
+[gd_scene load_steps=9 format=3 uid="uid://bnlxbdblgsb27"]
 
 [ext_resource type="Script" path="res://scripts/player_ship.gd" id="1_h4803"]
 [ext_resource type="PackedScene" uid="uid://bxv2hfmql2u5k" path="res://scenes/packed_scenes/circle.tscn" id="2_16oq7"]
@@ -6,6 +6,7 @@
 [ext_resource type="Script" path="res://scripts/score_counter.gd" id="4_ld3mo"]
 [ext_resource type="Script" path="res://scripts/ui_circle_feed.gd" id="4_ttudd"]
 [ext_resource type="PackedScene" uid="uid://cv07kcxkrys4i" path="res://scenes/packed_scenes/circle_ui.tscn" id="5_eotgi"]
+[ext_resource type="PackedScene" uid="uid://c4rj1nhxck7b3" path="res://scenes/packed_scenes/modifiers/test_modifier.tscn" id="7_a7hj1"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_mym6a"]
 font_size = 32
@@ -63,6 +64,20 @@ offset_bottom = 70.0
 theme_override_constants/separation = 0
 script = ExtResource("4_ttudd")
 circle = ExtResource("5_eotgi")
+
+[node name="UI_Modifiers" type="VBoxContainer" parent="CanvasLayer"]
+custom_minimum_size = Vector2(0, 100)
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -127.0
+offset_top = 80.0
+offset_right = -87.0
+offset_bottom = 120.0
+grow_horizontal = 0
+
+[node name="test_modifier" parent="CanvasLayer/UI_Modifiers" instance=ExtResource("7_a7hj1")]
+layout_mode = 2
 
 [connection signal="shot_fired" from="." to="FiringSystem" method="on_shot_fired"]
 [connection signal="body_entered" from="crush_detect" to="." method="_on_body_enter"]

--- a/scripts/circle.gd
+++ b/scripts/circle.gd
@@ -1,25 +1,27 @@
-extends RigidBody2D
+extends "res://scripts/circle_base.gd"
 
-@onready var collision = $"./CollisionShape2D"
-@onready var sprite = $"./Node2D"
-@onready var prox_detect = $"./ProxDetect"
+
 @export var attraction_strength_mult :float = 1
 @export var repulsion_strength_mult :float = 50
 
 
 var circle_size:int:
 	set(value):
-		var circle_scale = (value*.25) +.4
-		#TODO fix magic numbers?
-		collision.scale = Vector2(circle_scale,circle_scale)
-		sprite.scale = Vector2(circle_scale,circle_scale)
-
-		var prox_scale = (value*.25) +.4
-		#TODO fix magic numbers?
-		prox_detect.scale = Vector2(prox_scale,prox_scale)
-		sprite.scale = Vector2(prox_scale,prox_scale)
-
 		circle_size = value
+		circle_physics_properties_update(circle_size)
+
+		
+		#var circle_scale = (value*.25) +.4
+		#TODO fix magic numbers?
+		#collision.scale = Vector2(circle_scale,circle_scale)
+		#sprite.scale = Vector2(circle_scale,circle_scale)
+
+		#var prox_scale = (value*.25) +.4
+		#TODO fix magic numbers?
+		#prox_detect.scale = Vector2(prox_scale,prox_scale)
+		#sprite.scale = Vector2(prox_scale,prox_scale)
+
+		#circle_size = value
 		#TODO clean this up?
 	
 

--- a/scripts/circle.gd
+++ b/scripts/circle.gd
@@ -9,20 +9,6 @@ var circle_size:int:
 	set(value):
 		circle_size = value
 		circle_physics_properties_update(circle_size)
-
-		
-		#var circle_scale = (value*.25) +.4
-		#TODO fix magic numbers?
-		#collision.scale = Vector2(circle_scale,circle_scale)
-		#sprite.scale = Vector2(circle_scale,circle_scale)
-
-		#var prox_scale = (value*.25) +.4
-		#TODO fix magic numbers?
-		#prox_detect.scale = Vector2(prox_scale,prox_scale)
-		#sprite.scale = Vector2(prox_scale,prox_scale)
-
-		#circle_size = value
-		#TODO clean this up?
 	
 
 

--- a/scripts/circle.gd
+++ b/scripts/circle.gd
@@ -33,11 +33,11 @@ func collision_detect(body):
 			body.set_collision_mask_value(1,false)
 			self.linear_velocity = (self.linear_velocity+body.linear_velocity)/2.0
 			self.position = (self.position+body.position)/2.0
-			print("self position: ", self.position, ". colliding circle position: ", body.position, ". average: ", (self.position+body.position)/2.0)
-			print("self velocity: ", self.linear_velocity, ". colliding circle velocity: ", body.linear_velocity, ". average: ", (self.linear_velocity+body.linear_velocity)/2.0)
+			#print("self position: ", self.position, ". colliding circle position: ", body.position, ". average: ", (self.position+body.position)/2.0)
+			#print("self velocity: ", self.linear_velocity, ". colliding circle velocity: ", body.linear_velocity, ". average: ", (self.linear_velocity+body.linear_velocity)/2.0)
 			self.circle_size += 1
-			ScoreHandler.current_score += circle_size
-			print(ScoreHandler.current_score)
+			ScoreHandler.apply_score(self.position, self.circle_size)
+			#print(ScoreHandler.current_score)
 			#TODO: because velocities are being averaged after collision, behavior is a bit strange; not sure of a good fix but might be worth giving some thought
 
 

--- a/scripts/circle_base.gd
+++ b/scripts/circle_base.gd
@@ -1,0 +1,54 @@
+extends RigidBody2D
+
+
+@onready var collision = $"./CollisionShape2D"
+@onready var sprite = $"./Node2D"
+@onready var prox_detect = $"./ProxDetect"
+@onready var size_label = $"./SizeLabel"
+
+
+
+var scale_mult: float = .25
+var scale_addend: float = .4
+
+var prox_mult: float = .25
+var prox_addend: float = .4
+
+var mass_mult: float = .25
+var mass_addend: float = .4
+
+
+func set_circle_visual_scale(circle_size:int):
+    var circle_scale = (circle_size*scale_mult) + scale_addend
+    sprite.scale = Vector2(circle_scale,circle_scale)
+
+func set_circle_collision_scale(circle_size:int):
+    var circle_scale = (circle_size*scale_mult) + scale_addend
+    collision.scale = Vector2(circle_scale,circle_scale)
+
+func set_circle_prox_scale(circle_size:int):
+    var circle_scale = (circle_size*prox_mult) + prox_addend
+    prox_detect.scale = Vector2(circle_scale,circle_scale)
+
+func set_circle_mass(circle_size:int):
+    var circle_mass = (circle_size*mass_mult) + mass_addend
+    self.mass = circle_mass
+
+func set_circle_text(circle_size:int):
+    size_label.text = str(circle_size)
+
+
+func circle_physics_properties_update(circle_size:int):
+    set_circle_visual_scale(circle_size)
+    set_circle_collision_scale(circle_size)
+    set_circle_prox_scale(circle_size)
+    set_circle_mass(circle_size)
+    set_circle_text(circle_size)
+
+func circle_ui_properties_update(circle_size:int):
+    if circle_size < 0:
+        sprite.scale = Vector2(0,0)
+        size_label.text = ""
+    else:
+        set_circle_visual_scale(circle_size)
+        set_circle_text(circle_size)

--- a/scripts/circle_ui.gd
+++ b/scripts/circle_ui.gd
@@ -10,13 +10,6 @@ var circle_size:int:
         circle_size = value
         circle_ui_properties_update(circle_size)
 
-        #var circle_scale = (value*.25) +.4
-        #if circle_scale < .4:
-            #circle_scale = 0
-        #print("circle scale ", circle_scale)
-        #TODO fix magic numbers?
-        #sprite.scale = Vector2(circle_scale,circle_scale)
-
 
 var scale_mult: float = .25
 var scale_addend: float = .4

--- a/scripts/circle_ui.gd
+++ b/scripts/circle_ui.gd
@@ -1,21 +1,40 @@
 extends Control
 
+@onready var sprite = $"./Node2D"
+@onready var size_label = $"./SizeLabel"
+
+
 var circle_index:int
 var circle_size:int:
-	set(value):
-		var circle_scale = (value*.25) +.4
-		if circle_scale < .4:
-			circle_scale = 0
-		#print("circle scale ", circle_scale)
-		#TODO fix magic numbers?
-		sprite.scale = Vector2(circle_scale,circle_scale)
-var sprite
+    set(value):
+        circle_size = value
+        circle_ui_properties_update(circle_size)
 
-# Called when the node enters the scene tree for the first time.
-func _ready() -> void:
-	sprite = $"./Node2D"
+        #var circle_scale = (value*.25) +.4
+        #if circle_scale < .4:
+            #circle_scale = 0
+        #print("circle scale ", circle_scale)
+        #TODO fix magic numbers?
+        #sprite.scale = Vector2(circle_scale,circle_scale)
 
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(_delta: float) -> void:
-	pass
+var scale_mult: float = .25
+var scale_addend: float = .4
+
+func set_circle_visual_scale(_circle_size:int):
+    var circle_scale = (_circle_size*scale_mult) + scale_addend
+    sprite.scale = Vector2(circle_scale,circle_scale)
+
+func set_circle_text(_circle_size:int):
+    size_label.text = str(_circle_size)
+
+
+func circle_ui_properties_update(_circle_size:int):
+    if _circle_size < 0:
+        sprite.scale = Vector2(0,0)
+        size_label.text = ""
+    else:
+        set_circle_visual_scale(_circle_size)
+        set_circle_text(_circle_size)
+
+

--- a/scripts/modifiers/modifier.gd
+++ b/scripts/modifiers/modifier.gd
@@ -40,6 +40,7 @@ var map_size
 #current size of the map, based on score (to be passed in from elsewhere, not just calculated again here, in case other random nonsense gets factored in somewhere for some reason?)
 
 
+
 #quality and shininess of modifier, set when modifier is created, to augment numerical values inside it:
 
 var modifier_quality: int
@@ -50,13 +51,50 @@ var modifier_shininess: float
 
 
 
+
 #configurable elements to be used in modifiers, to be changed via upgrades in shops or something?:
 
-var modifier_invert: bool
+var modifier_invert: bool = false
 #configurable boolean to invert the behavior of the modifier
 
-var modifier_look_at
+var modifier_look_at: int
 #configurable indicator for left, right, first, last, etc; TODO replace this comment with a proper reference list and use an int value
 
-var modifier_circle_size
+var modifier_circle_size: int
 #configurable circle size to be compared against
+
+
+
+
+#constants for shininess/quality, to maybe be influenced externally in the future?
+
+var shininess_dist = 1.0
+#distribution of shininess curve
+
+var shininess_min = .5
+#minimum value for shininess; lower values on distribution curve will be changed to 1.0
+
+var quality_mult = 1.0
+#multiplier for chances of higher quality modifiers
+
+#modifier shininess and quality application:
+func _ready() -> void:
+    #TODO: add step to set above constants to match or be affected by external factors if applicable prior to shininess/quality calculation
+    var rand_int = randi() % 1000
+    var rand_float = randfn(1,shininess_dist)
+    if rand_float < shininess_min:
+        rand_float = 1
+    modifier_shininess = rand_float
+    if rand_int < quality_mult*1:
+        modifier_quality = 12
+    elif rand_int < quality_mult*5:
+        modifier_quality = 4
+    elif rand_int < quality_mult*25:
+        modifier_quality = 2
+    elif rand_int < quality_mult*200:
+        modifier_quality = 1
+    else:
+        modifier_quality = 0
+    
+
+#TODO add ui shape, text, etc. (instantiate another packed scene as child?); set up text to automatically update or something

--- a/scripts/modifiers/modifier.gd
+++ b/scripts/modifiers/modifier.gd
@@ -4,3 +4,59 @@ func calculate(_initial) -> float:
     print("Error: modifier lacks calculate function")
     return 0.0
 #TODO: swap out for proper error?
+
+
+
+#main variables potentially needed for calculating each score increase:
+
+var circle_size
+#resulting size of currently merging circles
+
+var combo
+#current combo
+
+var combo_max
+#max combo achieved this run
+
+var current_score
+#existing score prior to current merge's effects
+
+var merge_position
+#position where merge is happening
+
+var ship_position
+#position where the player's ship currently is
+
+var current_circles: Array
+#array containing all circles that currently exist, with circle size as the index; alternatively maybe this could potentially be a dictionary or something
+
+var full_deck: Array
+#array containing all circles in the player's current deck (including those already fired), in the current order
+
+var deck_index: int
+#index of next circle to be fired within player's current deck
+
+var map_size
+#current size of the map, based on score (to be passed in from elsewhere, not just calculated again here, in case other random nonsense gets factored in somewhere for some reason?)
+
+
+#quality and shininess of modifier, set when modifier is created, to augment numerical values inside it:
+
+var modifier_quality: int
+#quality of modifier, from +0 (functional) to +12 (impossible)
+
+var modifier_shininess: float
+#shininess of modifier, from *.5(corroded) to *10+ (otherworldly)
+
+
+
+#configurable elements to be used in modifiers, to be changed via upgrades in shops or something?:
+
+var modifier_invert: bool
+#configurable boolean to invert the behavior of the modifier
+
+var modifier_look_at
+#configurable indicator for left, right, first, last, etc; TODO replace this comment with a proper reference list and use an int value
+
+var modifier_circle_size
+#configurable circle size to be compared against

--- a/scripts/modifiers/modifier.gd
+++ b/scripts/modifiers/modifier.gd
@@ -1,0 +1,6 @@
+extends Node
+
+func calculate(_initial) -> float:
+    print("Error: modifier lacks calculate function")
+    return 0.0
+#TODO: swap out for proper error?

--- a/scripts/modifiers/modifier.gd
+++ b/scripts/modifiers/modifier.gd
@@ -28,7 +28,7 @@ var ship_position
 #position where the player's ship currently is
 
 var current_circles: Array
-#array containing all circles that currently exist, with circle size as the index; alternatively maybe this could potentially be a dictionary or something
+#array containing all circles that currently exist; alternatively maybe this could potentially be a dictionary or something
 
 var full_deck: Array
 #array containing all circles in the player's current deck (including those already fired), in the current order
@@ -38,6 +38,13 @@ var deck_index: int
 
 var map_size
 #current size of the map, based on score (to be passed in from elsewhere, not just calculated again here, in case other random nonsense gets factored in somewhere for some reason?)
+
+
+var modifier_variable_1: float
+var modifier_variable_2: float
+var modifier_variable_3: float
+#various simple variables to be used by modifiers in different ways
+
 
 
 
@@ -77,9 +84,30 @@ var shininess_min = .5
 var quality_mult = 1.0
 #multiplier for chances of higher quality modifiers
 
-#modifier shininess and quality application:
-func _ready() -> void:
-    #TODO: add step to set above constants to match or be affected by external factors if applicable prior to shininess/quality calculation
+
+
+#bringing in ui elements, setting text
+
+var modifier_ui_name_label: Label
+var modifier_ui_description_label: Label
+
+var modifier_ui_name:
+    set(text):
+        modifier_ui_name = text
+        modifier_ui_name_label.text = text
+
+var modifier_ui_description:
+    set(text):
+        modifier_ui_description = text
+        modifier_ui_description_label.text = text
+
+
+
+
+func modifier_initialize():
+       
+    #modifier shininess and quality application:
+    #TODO: add step to set q/s constants to match or be affected by external factors if applicable prior to shininess/quality calculation
     var rand_int = randi() % 1000
     var rand_float = randfn(1,shininess_dist)
     if rand_float < shininess_min:
@@ -95,6 +123,19 @@ func _ready() -> void:
         modifier_quality = 1
     else:
         modifier_quality = 0
-    
+	
+    var modifier_ui = preload("res://scenes/packed_scenes/modifier_ui.tscn").instantiate()
+    add_child(modifier_ui)
+    modifier_ui_name_label = $"./ModifierUI/ModifierName"
+    modifier_ui_description_label = $"./ModifierUI/ModifierDescription"
 
-#TODO add ui shape, text, etc. (instantiate another packed scene as child?); set up text to automatically update or something
+
+    modifier_ui_name = "yer modifier's broken, friend"
+    modifier_ui_description = "this here is text y'all shouldn't be seeing unless the game is doing something shall we say more than a bit incorrect"
+
+
+
+
+#function to apply quality and shininess to a given input
+func apply_qs(input) -> float:
+    return (input+modifier_quality)*modifier_shininess

--- a/scripts/modifiers/modifier.gd
+++ b/scripts/modifiers/modifier.gd
@@ -10,6 +10,7 @@ const MODIFIER_UI_PATH = "res://scenes/packed_scenes/modifier_ui.tscn"
 
 
 
+
 #main variables potentially needed for calculating each score increase:
 
 var modifier_active: bool = true
@@ -17,48 +18,100 @@ var modifier_active: bool = true
 var circle_size
 #resulting size of currently merging circles
 
-var combo
-#current combo
-
-var combo_max
-#max combo achieved this run
-
-var current_score
-#existing score prior to current merge's effects
-
 var merge_position
 #position where merge is happening
 
 var ship_position
 #position where the player's ship currently is
 
-var current_circles: Array
+var combo:
+    set(input):
+        combo = input
+        update_name_description()
+#current combo
+
+var combo_max:
+    set(input):
+        combo_max = input
+        update_name_description()
+#max combo achieved this run
+
+var current_score:
+    set(input):
+        current_score = input
+        update_name_description()
+#existing score prior to current merge's effects
+
+var current_circles: Array:
+    set(input):
+        current_circles = input
+        update_name_description()
 #array containing all circles that currently exist; alternatively maybe this could potentially be a dictionary or something
 
-var full_deck: Array
+var full_deck: Array:
+    set(input):
+        full_deck = input
+        update_name_description()
 #array containing all circles in the player's current deck (including those already fired), in the current order
 
-var deck_index: int
+var deck_index: int:
+    set(input):
+        deck_index = input
+        update_name_description()
 #index of next circle to be fired within player's current deck
 
-var map_size
+var map_size: float:
+    set(input):
+        map_size = input
+        update_name_description()
 #current size of the map, based on score (to be passed in from elsewhere, not just calculated again here, in case other random nonsense gets factored in somewhere for some reason?)
 
 
-var modifier_variable_1: float
-var modifier_variable_2: float
-var modifier_variable_3: float
-#various simple variables to be used by modifiers in different ways
+var modifier_variable_1: float:
+    set(input):
+        modifier_variable_1 = input
+        apply_qs_all()
+var modifier_variable_2: float:
+    set(input):
+        modifier_variable_2 = input
+        apply_qs_all()
+var modifier_variable_3: float:
+    set(input):
+        modifier_variable_3 = input
+        apply_qs_all()
+
+var modifier_variable_1_qs: float:
+    set(input):
+        modifier_variable_1_qs = input
+        update_name_description()
+var modifier_variable_2_qs: float:
+    set(input):
+        modifier_variable_2_qs = input
+        update_name_description()
+var modifier_variable_3_qs: float:
+    set(input):
+        modifier_variable_3_qs = input
+        update_name_description()
+#various simple variables to be used by modifiers in different ways, and the q/s adjusted versions of those variables
+
 
 
 
 
 #quality and shininess of modifier, set when modifier is created, to augment numerical values inside it:
 
-var modifier_quality: int
+var modifier_quality: int:
+    set(input):
+        modifier_quality = input
+        apply_qs_all()
+        update_name_description()
 #quality of modifier, from +0 (functional) to +12 (impossible)
 
-var modifier_shininess: float
+var modifier_shininess: float:
+    set(input):
+        modifier_shininess = input
+        apply_qs_all()
+        update_name_description()
 #shininess of modifier, from *.5(corroded) to *10+ (otherworldly)
 
 
@@ -66,19 +119,29 @@ var modifier_shininess: float
 
 #configurable elements to be used in modifiers, to be changed via upgrades in shops or something?:
 
-var modifier_invert: bool = false
+var modifier_invert: bool = false:
+    set(input):
+        modifier_invert = input
+        update_name_description()
 #configurable boolean to invert the behavior of the modifier
 
-var modifier_look_at: int
-#configurable indicator for left, right, first, last, etc; TODO replace this comment with a proper reference list and use an int value
+var modifier_look_at: int:
+    set(input):
+        modifier_look_at = input
+        update_name_description()
+var look_at_key: Array = ["first", "second", "last", "previous", "next", "random"]
+#configurable indicator for first, second, last, previous, next, random (int index 0-5 respectively) and key for same
 
-var modifier_circle_size: int
+var modifier_circle_size_variable: int:
+    set(input):
+        modifier_circle_size_variable = input
+        update_name_description()
 #configurable circle size to be compared against
 
 
 
 
-#constants for shininess/quality, to maybe be influenced externally in the future?
+#constants for initial generation of shininess/quality, to maybe be influenced externally in the future?
 
 var shininess_dist = 1.0
 #distribution of shininess curve
@@ -89,6 +152,13 @@ var shininess_min = .5
 var quality_mult = 1.0
 #multiplier for chances of higher quality modifiers
 
+
+
+#raw input name and description of modifier, to be amended with augmented/upgraded values etc
+#input to be formatted as an array, with strings and variables etc in order as they should appear
+
+var modifier_ui_name_raw: Array
+var modifier_ui_description_raw: Array
 
 
 #text for ui; label text will be automatically updated as variables are changed
@@ -110,8 +180,15 @@ var modifier_ui_description: String:
 
 #main initialization, to be called with a ready function in any/all modifiers
 
-func modifier_initialize(modifier_ui_name_input: String, modifier_ui_description_input: String):
-       
+func modifier_initialize():
+    #bringing in ui stuff and setting initial label text:
+
+    var modifier_ui = preload(MODIFIER_UI_PATH).instantiate()
+    add_child(modifier_ui)
+    modifier_ui_name_label = $"./ModifierUI/ModifierName"
+    modifier_ui_description_label = $"./ModifierUI/ModifierDescription"
+
+
     #modifier shininess and quality application:
     #TODO: add step to set q/s constants to match or be affected by external factors if applicable prior to shininess/quality calculation
     var rand_int = randi() % 1000
@@ -129,24 +206,70 @@ func modifier_initialize(modifier_ui_name_input: String, modifier_ui_description
         modifier_quality = 1
     else:
         modifier_quality = 0
-	
-
-    #bringing in ui stuff and setting initial label text:
-
-    var modifier_ui = preload(MODIFIER_UI_PATH).instantiate()
-    add_child(modifier_ui)
-    modifier_ui_name_label = $"./ModifierUI/ModifierName"
-    modifier_ui_description_label = $"./ModifierUI/ModifierDescription"
 
 
-    if modifier_ui_name_input:
-        modifier_ui_name = modifier_ui_name_input
+    #update_name_description()
+
+
+
+#function to convert an array of arbitrary strings and variables to a single string.
+#definitely feels like there should be a better way to do this nonsense but heck if I know it
+func text_array_to_string(array:Array) -> String:
+    var result: String
+    for item in array:
+        if typeof(item) != TYPE_STRING:
+            result = result + "ERROR_DATATYPE_IN_ARRAY"
+        if item.contains("["):
+            if item == "[v1]":
+                result = result + str(limit_decimals(modifier_variable_1_qs, 2))
+            elif item == "[v2]":
+                result = result + str(limit_decimals(modifier_variable_2_qs, 2))
+            elif item == "[v3]":
+                result = result + str(limit_decimals(modifier_variable_3_qs, 2))
+            elif item == "[lookat]":
+                result = result + str(look_at_key[modifier_look_at])
+            elif item == "[csize]":
+                result = result + "circle size " + str(modifier_circle_size_variable)
+            elif item == "[combo]":
+                result = result + str(combo) + " (current combo)"
+            elif item == "[combomax]":
+                result = result + str(combo_max) + " (max combo reached)"
+            elif item == "[score]":
+                result = result + str(current_score) + " (current score)"
+            elif item == "[deckindex]":
+                result = result + str(deck_index) + " (current shot index in deck)"
+            elif item == "[mapsize]":
+                result = result + str(limit_decimals(map_size, 2)) + " (map size)"
+            elif item == "[cnumber]":
+                result = result + str(current_circles.size()) + " (current number of circles)"
+            elif item == "[decksize]":
+                result = result + str(full_deck.size()) + " (current deck size)"
+            else:
+                result = result + item
+        else:
+            result = result + item
+        
+    return result
+
+
+
+#function to update name and description of modifier, using raw input arrays and current applicable variable values
+func update_name_description():
+    if modifier_ui_name_raw:
+        modifier_ui_name = text_array_to_string(modifier_ui_name_raw)
     else:
         modifier_ui_name = "yer modifier's broken, friend"
-    if modifier_ui_description_input:
-        modifier_ui_description = modifier_ui_description_input
+    if modifier_ui_description_raw:
+        modifier_ui_description = text_array_to_string(modifier_ui_description_raw)
     else:
         modifier_ui_description = "this here is text y'all shouldn't be seeing unless the game is doing something shall we say more than a bit incorrect"
+
+
+
+
+func limit_decimals(input:float, decimal_places:int) -> float:
+    var order_of_magnitude = 10**decimal_places
+    return floorf(input*order_of_magnitude)/order_of_magnitude 
 
 
 
@@ -154,3 +277,13 @@ func modifier_initialize(modifier_ui_name_input: String, modifier_ui_description
 #function to apply quality and shininess to a given input
 func apply_qs(input) -> float:
     return (input+modifier_quality)*modifier_shininess
+    
+
+#function to apply quality and shininess to all variables
+func apply_qs_all():
+    if modifier_variable_1:
+        modifier_variable_1_qs = apply_qs(modifier_variable_1)
+    if modifier_variable_2:
+        modifier_variable_2_qs = apply_qs(modifier_variable_2)
+    if modifier_variable_3:
+        modifier_variable_3_qs = apply_qs(modifier_variable_3)

--- a/scripts/modifiers/modifier.gd
+++ b/scripts/modifiers/modifier.gd
@@ -5,9 +5,14 @@ func calculate(_initial) -> float:
     return 0.0
 #TODO: swap out for proper error?
 
+#path to modifier ui packed scene
+const MODIFIER_UI_PATH = "res://scenes/packed_scenes/modifier_ui.tscn"
+
 
 
 #main variables potentially needed for calculating each score increase:
+
+var modifier_active: bool = true
 
 var circle_size
 #resulting size of currently merging circles
@@ -86,25 +91,26 @@ var quality_mult = 1.0
 
 
 
-#bringing in ui elements, setting text
+#text for ui; label text will be automatically updated as variables are changed
 
 var modifier_ui_name_label: Label
 var modifier_ui_description_label: Label
 
-var modifier_ui_name:
+var modifier_ui_name: String:
     set(text):
         modifier_ui_name = text
         modifier_ui_name_label.text = text
 
-var modifier_ui_description:
+var modifier_ui_description: String:
     set(text):
         modifier_ui_description = text
         modifier_ui_description_label.text = text
 
 
 
+#main initialization, to be called with a ready function in any/all modifiers
 
-func modifier_initialize():
+func modifier_initialize(modifier_ui_name_input: String, modifier_ui_description_input: String):
        
     #modifier shininess and quality application:
     #TODO: add step to set q/s constants to match or be affected by external factors if applicable prior to shininess/quality calculation
@@ -124,14 +130,23 @@ func modifier_initialize():
     else:
         modifier_quality = 0
 	
-    var modifier_ui = preload("res://scenes/packed_scenes/modifier_ui.tscn").instantiate()
+
+    #bringing in ui stuff and setting initial label text:
+
+    var modifier_ui = preload(MODIFIER_UI_PATH).instantiate()
     add_child(modifier_ui)
     modifier_ui_name_label = $"./ModifierUI/ModifierName"
     modifier_ui_description_label = $"./ModifierUI/ModifierDescription"
 
 
-    modifier_ui_name = "yer modifier's broken, friend"
-    modifier_ui_description = "this here is text y'all shouldn't be seeing unless the game is doing something shall we say more than a bit incorrect"
+    if modifier_ui_name_input:
+        modifier_ui_name = modifier_ui_name_input
+    else:
+        modifier_ui_name = "yer modifier's broken, friend"
+    if modifier_ui_description_input:
+        modifier_ui_description = modifier_ui_description_input
+    else:
+        modifier_ui_description = "this here is text y'all shouldn't be seeing unless the game is doing something shall we say more than a bit incorrect"
 
 
 

--- a/scripts/modifiers/modifier.gd
+++ b/scripts/modifiers/modifier.gd
@@ -1,8 +1,8 @@
 extends Node
 
 func calculate(_initial) -> float:
-    print("Error: modifier lacks calculate function")
-    return 0.0
+    print("ERROR: modifier lacks calculate function")
+    return _initial
 #TODO: swap out for proper error?
 
 #path to modifier ui packed scene
@@ -178,15 +178,25 @@ var modifier_ui_description: String:
 
 
 
+#sources for signals
+var score_handler = ScoreHandler
+
+
+
 #main initialization, to be called with a ready function in any/all modifiers
 
 func modifier_initialize():
-    #bringing in ui stuff and setting initial label text:
 
+    #bringing in ui stuff:
     var modifier_ui = preload(MODIFIER_UI_PATH).instantiate()
     add_child(modifier_ui)
     modifier_ui_name_label = $"./ModifierUI/ModifierName"
     modifier_ui_description_label = $"./ModifierUI/ModifierDescription"
+
+
+    #hooking up functions to signals and priming them to prevent null values (TODO: add the rest once they're available):
+    score_handler.points_added.connect(current_score_update)
+    current_score_update(score_handler.current_score)
 
 
     #modifier shininess and quality application:
@@ -208,12 +218,10 @@ func modifier_initialize():
         modifier_quality = 0
 
 
-    #update_name_description()
-
 
 
 #function to convert an array of arbitrary strings and variables to a single string.
-#definitely feels like there should be a better way to do this nonsense but heck if I know it
+#(definitely feels like there should be a better way to do this nonsense but heck if I know it)
 func text_array_to_string(array:Array) -> String:
     var result: String
     for item in array:
@@ -253,6 +261,12 @@ func text_array_to_string(array:Array) -> String:
 
 
 
+
+#function to receive signal from score_handler and update player score dynamically
+func current_score_update(score):
+    current_score = score
+
+
 #function to update name and description of modifier, using raw input arrays and current applicable variable values
 func update_name_description():
     if modifier_ui_name_raw:
@@ -267,6 +281,8 @@ func update_name_description():
 
 
 
+#function to limit the number of decimal places of a float
+#TODO: refine at some point to do significant figures instead, or replace with another function that does that?
 func limit_decimals(input:float, decimal_places:int) -> float:
     var order_of_magnitude = 10**decimal_places
     return floorf(input*order_of_magnitude)/order_of_magnitude 

--- a/scripts/modifiers/test_modifier.gd
+++ b/scripts/modifiers/test_modifier.gd
@@ -1,11 +1,18 @@
 extends "res://scripts/modifiers/modifier.gd"
 
 
-var test_addend = 1
+func _ready() -> void:
+    modifier_initialize()
+    modifier_ui_name = "Test Modifier"
+    modifier_ui_description = "Adds 1 to score as it's earned."
+    #TODO: need to establish system/technique for changing numbers/etc, in this case the 1, dynamically as appropriate
+
 
 func calculate(initial) -> float:
     
-    test_addend = (test_addend+modifier_quality)*modifier_shininess
+    modifier_variable_1 = 1
+    
+    apply_qs(modifier_variable_1)
 
-    var result = initial + test_addend
+    var result = initial + modifier_variable_1
     return result

--- a/scripts/modifiers/test_modifier.gd
+++ b/scripts/modifiers/test_modifier.gd
@@ -2,17 +2,21 @@ extends "res://scripts/modifiers/modifier.gd"
 
 
 func _ready() -> void:
-    modifier_initialize()
-    modifier_ui_name = "Test Modifier"
-    modifier_ui_description = "Adds 1 to score as it's earned."
+    modifier_initialize("Test Modifier","Adds 1 to score as it's earned.")
+    
     #TODO: need to establish system/technique for changing numbers/etc, in this case the 1, dynamically as appropriate
+    #will need to update when q/s or the variable(s) or parameters in question change
 
 
 func calculate(initial) -> float:
-    
-    modifier_variable_1 = 1
-    
-    apply_qs(modifier_variable_1)
 
-    var result = initial + modifier_variable_1
-    return result
+    if modifier_active:
+
+        modifier_variable_1 = 1
+    
+        apply_qs(modifier_variable_1)
+
+        var result = initial + modifier_variable_1
+        return result
+    else:
+        return initial

--- a/scripts/modifiers/test_modifier.gd
+++ b/scripts/modifiers/test_modifier.gd
@@ -9,7 +9,7 @@ func _ready() -> void:
     modifier_initialize()
 
     modifier_variable_1 = 1
-    print ("quality: "+str(modifier_quality)+" shininess: "+str(modifier_shininess)+"; variable 1 raw: "+str(modifier_variable_1)+ " variable 1 qs adjusted: "+str(modifier_variable_1_qs))
+    #print ("quality: "+str(modifier_quality)+" shininess: "+str(modifier_shininess)+"; variable 1 raw: "+str(modifier_variable_1)+ " variable 1 qs adjusted: "+str(modifier_variable_1_qs))
     
     
 
@@ -21,5 +21,5 @@ func calculate(initial) -> float:
         return floori(result)
     else:
         return initial
-#floor after calculation, before return, not on individual variables (doesn't matter here, but would make a difference in other cases)
-#TODO maybe even floor in the end after all calculations, not within modifiers?
+
+#TODO floor in the end after all calculations, not within modifiers

--- a/scripts/modifiers/test_modifier.gd
+++ b/scripts/modifiers/test_modifier.gd
@@ -2,21 +2,24 @@ extends "res://scripts/modifiers/modifier.gd"
 
 
 func _ready() -> void:
-    modifier_initialize("Test Modifier","Adds 1 to score as it's earned.")
+    modifier_ui_name_raw = ["Test Modifier"]
+    modifier_ui_description_raw = ["Adds ", "[v1]", " to score as it's earned."]
     
-    #TODO: need to establish system/technique for changing numbers/etc, in this case the 1, dynamically as appropriate
-    #will need to update when q/s or the variable(s) or parameters in question change
+    
+    modifier_initialize()
+
+    modifier_variable_1 = 1
+    print ("quality: "+str(modifier_quality)+" shininess: "+str(modifier_shininess)+"; variable 1 raw: "+str(modifier_variable_1)+ " variable 1 qs adjusted: "+str(modifier_variable_1_qs))
+    
+    
 
 
 func calculate(initial) -> float:
 
     if modifier_active:
-
-        modifier_variable_1 = 1
-    
-        apply_qs(modifier_variable_1)
-
-        var result = initial + modifier_variable_1
-        return result
+        var result = initial + modifier_variable_1_qs
+        return floori(result)
     else:
         return initial
+#floor after calculation, before return, not on individual variables (doesn't matter here, but would make a difference in other cases)
+#TODO maybe even floor in the end after all calculations, not within modifiers?

--- a/scripts/modifiers/test_modifier.gd
+++ b/scripts/modifiers/test_modifier.gd
@@ -1,6 +1,11 @@
 extends "res://scripts/modifiers/modifier.gd"
 
 
+var test_addend = 1
+
 func calculate(initial) -> float:
-    var result = initial +1
+    
+    test_addend = (test_addend+modifier_quality)*modifier_shininess
+
+    var result = initial + test_addend
     return result

--- a/scripts/modifiers/test_modifier.gd
+++ b/scripts/modifiers/test_modifier.gd
@@ -1,0 +1,6 @@
+extends "res://scripts/modifiers/modifier.gd"
+
+
+func calculate(initial) -> float:
+    var result = initial +1
+    return result

--- a/scripts/score_handler.gd
+++ b/scripts/score_handler.gd
@@ -17,6 +17,7 @@ signal points_added(points)
 func _ready() -> void:
     #var test_modifier = preload("res://scenes/packed_scenes/modifiers/test_modifier.tscn").instantiate()
     #add_child(test_modifier)
+    #^this kind of malarkey will be happening in the shop or whatever, not here
     modifiers_array = get_tree().get_root().get_node("Main/Ship/CanvasLayer/UI_Modifiers").get_children()
     print(get_tree().get_root().get_node("Main/Ship/CanvasLayer/UI_Modifiers").get_children())
     pass

--- a/scripts/score_handler.gd
+++ b/scripts/score_handler.gd
@@ -24,11 +24,9 @@ func _ready() -> void:
 
 
 func apply_score(_merge_position:Vector2, merge_result_size:int):
-    print("apply_score called with merge_result_size = ", merge_result_size)
+    #print("apply_score called with merge_result_size = ", merge_result_size)
     var score_temp = merge_result_size
     for modifier in modifiers_array:
-        print("should be merged circle size +1: ",modifier.calculate(score_temp))
-
         score_temp =  modifier.calculate(score_temp)
     current_score += score_temp
     

--- a/scripts/score_handler.gd
+++ b/scripts/score_handler.gd
@@ -4,10 +4,6 @@ extends Node
 var modifiers_array: Array
 
 
-func _ready() -> void:
-	var test_modifier = preload("res://scenes/packed_scenes/modifiers/test_modifier.tscn").instantiate()
-	add_child(test_modifier)
-	modifiers_array = [test_modifier]
 
 var current_score: int:
 	set(value):
@@ -17,11 +13,21 @@ var current_score: int:
 #Signals
 signal points_added(points)
 
+
+func _ready() -> void:
+	var test_modifier = preload("res://scenes/packed_scenes/modifiers/test_modifier.tscn").instantiate()
+	add_child(test_modifier)
+	modifiers_array = [test_modifier]
+	#^all this is temporary, populate the array with modifier nodes properly from wherever
+
+
 func apply_score(_merge_position:Vector2, merge_result_size:int):
 	print("apply_score called with merge_result_size = ", merge_result_size)
+	var score_temp = merge_result_size
 	for modifier in modifiers_array:
-		print("should be merged circle size +1: ",modifier.calculate(merge_result_size))
+		print("should be merged circle size +1: ",modifier.calculate(score_temp))
 
-		current_score += modifier.calculate(merge_result_size)
+		score_temp =  modifier.calculate(score_temp)
+	current_score += score_temp
 	
 

--- a/scripts/score_handler.gd
+++ b/scripts/score_handler.gd
@@ -6,28 +6,28 @@ var modifiers_array: Array
 
 
 var current_score: int:
-	set(value):
-		current_score = value
-		points_added.emit(value)
+    set(value):
+        current_score = value
+        points_added.emit(value)
 
 #Signals
 signal points_added(points)
 
 
 func _ready() -> void:
-	var test_modifier = preload("res://scenes/packed_scenes/modifiers/test_modifier.tscn").instantiate()
-	add_child(test_modifier)
-	modifiers_array = [test_modifier]
-	#^all this is temporary, populate the array with modifier nodes properly from wherever
+    #var test_modifier = preload("res://scenes/packed_scenes/modifiers/test_modifier.tscn").instantiate()
+    #add_child(test_modifier)
+    modifiers_array = get_tree().get_root().get_node("Main/Ship/CanvasLayer/UI_Modifiers").get_children()
+    print(get_tree().get_root().get_node("Main/Ship/CanvasLayer/UI_Modifiers").get_children())
+    pass
 
 
 func apply_score(_merge_position:Vector2, merge_result_size:int):
-	print("apply_score called with merge_result_size = ", merge_result_size)
-	var score_temp = merge_result_size
-	for modifier in modifiers_array:
-		print("should be merged circle size +1: ",modifier.calculate(score_temp))
+    print("apply_score called with merge_result_size = ", merge_result_size)
+    var score_temp = merge_result_size
+    for modifier in modifiers_array:
+        print("should be merged circle size +1: ",modifier.calculate(score_temp))
 
-		score_temp =  modifier.calculate(score_temp)
-	current_score += score_temp
-	
-
+        score_temp =  modifier.calculate(score_temp)
+    current_score += score_temp
+    

--- a/scripts/score_handler.gd
+++ b/scripts/score_handler.gd
@@ -1,5 +1,14 @@
 extends Node
 
+#TODO: read modifiers player has, pass into array
+var modifiers_array: Array
+
+
+func _ready() -> void:
+	var test_modifier = preload("res://scenes/packed_scenes/modifiers/test_modifier.tscn").instantiate()
+	add_child(test_modifier)
+	modifiers_array = [test_modifier]
+
 var current_score: int:
 	set(value):
 		current_score = value
@@ -8,8 +17,11 @@ var current_score: int:
 #Signals
 signal points_added(points)
 
-func _ready():
-	pass
+func apply_score(_merge_position:Vector2, merge_result_size:int):
+	print("apply_score called with merge_result_size = ", merge_result_size)
+	for modifier in modifiers_array:
+		print("should be merged circle size +1: ",modifier.calculate(merge_result_size))
 
-func _process(_delta: float) -> void:
-	pass
+		current_score += modifier.calculate(merge_result_size)
+	
+


### PR DESCRIPTION
Framework for score modifiers implemented. Modifiers will be packed scenes each containing a single control node with a script that extends the main 'modifier' script, and which contains at minimum:
-a ready function that specifies arrays to generate the modifier's name and description, calls the 'modifier_initialize()' function, and provides default values for any variables used;
-a calculate(input:float) -> float function which, if the modifier is active, augments the input in some way as described by the description, returning the result.

Modifiers will dynamically update their internal variables based on the current state of the game if they refer to things like current combo or map size; proof of concept for this behavior has been implemented.

Modifiers will be obtained via a shop or other means, and placed into the UI_Modifiers VBoxContainer in the CanvasLayer of the player's ship. Any modifiers that are children of UI_Modifiers (and only them) will, in order, have their effects applied to score as it is earned.

Quality and shininess have also been implemented for modifiers to augment their functioning.